### PR TITLE
docs/community hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files owned by:
+* @CoderDeltaLAN

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Report a reproducible problem
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Include expected vs actual behavior.
+      placeholder: Clear, concise description...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Command run
+        2. Output
+        3. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Traceback
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,15 @@
+name: Feature request
+description: Suggest an idea
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      placeholder: What problem does this solve?
+    validations:
+      required: true
+  - type: input
+    id: motivation
+    attributes:
+      label: Motivation / Use case

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+## How to test
+- Run `poetry install`
+- `poetry run ruff check . && poetry run black --check . && PYTHONPATH=src poetry run pytest -q && poetry run mypy .`
+
+## Checklist
+- [ ] Tests pass
+- [ ] Lint passes (ruff/black/mypy)
+- [ ] Ready label added; not a draft
+- [ ] No unrelated changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,40 @@
-name: Release to PyPI
+name: ci: publish to PyPI on tag
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*.*.*']
+
 permissions:
   contents: read
-  id-token: write
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: true
+
 jobs:
-  build-and-publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: No token -> saltar publicación (todo verde)
+        if: ${{ secrets.PYPI_API_TOKEN == '' }}
+        run: echo "PYPI_API_TOKEN no configurado; publicación omitida."
+
       - uses: actions/setup-python@v5
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
         with:
-          python-version: '3.11'
+          python-version: '3.12'
+
       - uses: abatilo/actions-poetry@v3
-      - name: Install deps
-        run: poetry install --no-interaction
-      - name: Build package
-        run: poetry build
-      - name: Twine check
-        run: python -m pip install -q twine && twine check dist/*
-      - name: Publish to PyPI (token secret)
-        uses: pypa/gh-action-pypi-publish@v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+
+      - name: Build
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        run: |
+          poetry build
+          python -m pip install -q twine
+          twine check dist/*
+
+      - name: Publish to PyPI
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m pip install -q twine
+          twine upload -u __token__ -p "$PYPI_API_TOKEN" dist/*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+title: license-guardian
+message: "Please cite this software as below."
+authors:
+  - family-names: "CoderDeltaLAN"
+    given-names: "Yosvel"
+license: MIT
+repository-code: "https://github.com/CoderDeltaLAN/license-guardian"
+version: "0.1.1"
+date-released: "2025-09-09"
+keywords: [spdx, license, headers, compliance, cli, python]
+preferred-citation:
+  type: software
+  authors:
+    - family-names: "CoderDeltaLAN"
+      given-names: "Yosvel"
+  title: "license-guardian"
+  url: "https://github.com/CoderDeltaLAN/license-guardian"
+  year: 2025

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Use Poetry locally. Before any push:
+
+```bash
+poetry run ruff check . --fix
+poetry run ruff format .
+poetry run black .
+PYTHONPATH=src poetry run pytest -q
+poetry run mypy .
+```
+
+Small, atomic PRs. Follow Conventional Commits. CI must be green.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,2 @@
+Copyright (c) 2025 CoderDeltaLAN (Yosvel)
+Released under the MIT License — see LICENSE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+license-guardian — Copyright (c) 2025 CoderDeltaLAN (Yosvel)
+
+Licensed under the MIT License. See LICENSE.
+
+Redistributions must retain this NOTICE and the LICENSE file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+- Report vulnerabilities via email: coderdeltalan.cargo784@8alias.com
+- Include steps to reproduce and affected versions.
+- Do not open public issues for undisclosed vulnerabilities.


### PR DESCRIPTION
- **ci: guard release — skip publish when PYPI token missing**
- **docs: community hardening (SECURITY, CONTRIBUTING, templates, CODEOWNERS, CITATION)**
